### PR TITLE
Feature/fix order of dispose

### DIFF
--- a/packages/with_bloc/lib/src/with_bloc.dart
+++ b/packages/with_bloc/lib/src/with_bloc.dart
@@ -55,9 +55,11 @@ class WithBlocState<BlocType extends ValueNotifier<StateType>, StateType>
     super.didUpdateWidget(oldWidget);
 
     if (!listId.equals(oldWidget.inputs, widget.inputs)) {
-      setState(() {
-        bloc = widget.createBloc(context);
-      });
+      /// Dispose the old bloc
+      bloc.dispose();
+
+      /// Recreate the bloc
+      bloc = widget.createBloc(context);
     }
   }
 

--- a/packages/with_bloc/lib/src/with_bloc.dart
+++ b/packages/with_bloc/lib/src/with_bloc.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -55,7 +57,6 @@ class WithBlocState<BlocType extends ValueNotifier<StateType>, StateType>
     super.didUpdateWidget(oldWidget);
 
     if (!listId.equals(oldWidget.inputs, widget.inputs)) {
-      /// Dispose the old bloc
       bloc.dispose();
 
       /// Recreate the bloc

--- a/packages/with_bloc/lib/src/with_bloc.dart
+++ b/packages/with_bloc/lib/src/with_bloc.dart
@@ -63,9 +63,9 @@ class WithBlocState<BlocType extends ValueNotifier<StateType>, StateType>
 
   @override
   void dispose() {
-    super.dispose();
-
     bloc.dispose();
+
+    super.dispose();
   }
 
   @override

--- a/packages/with_bloc/test/with_bloc/disposable_bloc.dart
+++ b/packages/with_bloc/test/with_bloc/disposable_bloc.dart
@@ -1,0 +1,16 @@
+import 'package:state_queue/state_queue.dart';
+
+class DisposableBloc extends StateQueue<int> {
+  DisposableBloc({
+    this.onDispose,
+  }) : super(0);
+
+  final void Function() onDispose;
+
+  @override
+  void dispose() {
+    super.dispose();
+
+    onDispose();
+  }
+}

--- a/packages/with_bloc/test/with_bloc/with_bloc_test.dart
+++ b/packages/with_bloc/test/with_bloc/with_bloc_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:with_bloc/with_bloc.dart';
 
 import 'async_increment_bloc.dart';
+import 'disposable_bloc.dart';
 
 Future<void> main() async {
   testWidgets(
@@ -78,6 +79,64 @@ Future<void> main() async {
         expect(firstBloc != secondBloc, true);
 
         expect(secondState.count, 0);
+      });
+    },
+  );
+
+  testWidgets(
+    'Disposes old bloc if new one gets created',
+    (tester) async {
+      await tester.runAsync(() async {
+        var createdInstances = 0;
+        var disposedInstances = 0;
+
+        DisposableBloc createBloc(BuildContext context) {
+          createdInstances++;
+
+          return DisposableBloc(
+            onDispose: () {
+              /// Increment the counter when the bloc get's disposed
+              disposedInstances++;
+            },
+          );
+        }
+
+        await tester.pumpWidget(
+          WithBloc<DisposableBloc, int>(
+            createBloc: createBloc,
+            inputs: <dynamic>[1],
+            builder: (context, bloc, state, child) {
+              return Container();
+            },
+          ),
+        );
+
+        /// Only one instance should be created and none should be disposed after the initial render
+        expect(createdInstances, 1);
+        expect(disposedInstances, 0);
+
+        /// Rerender the widget with different inputs to trigger an update of the bloc
+        await tester.pumpWidget(
+          WithBloc<DisposableBloc, int>(
+            createBloc: createBloc,
+            inputs: <dynamic>[999],
+            builder: (context, bloc, state, child) {
+              return Container();
+            },
+          ),
+        );
+
+        /// Should have create a new one and disposed the old one
+        expect(createdInstances, 2);
+        expect(disposedInstances, 1);
+
+        await tester.pumpWidget(
+          Container(),
+        );
+
+        /// Should have disposed the current instance due to the widget being unmounted
+        expect(createdInstances, 2);
+        expect(disposedInstances, 2);
       });
     },
   );


### PR DESCRIPTION
@tp I just noticed that we are not disposing the bloc when we create a new one because of changed inputs.

What is tricky here is that we can't just call `dispose` on it because then the `removeListener` in the `ValueListenableBuilder` would fail. Any ideas around the issue? We could save the old bloc instance and then potential call it in the `builder` method but this seems more like a hack too me.

I have added a test that makes sure that we create the correct amount of instances and then also dispose them correctly which currently fails because of that.