### PR TITLE
Re-declared a method in the Android wrapper

### DIFF
--- a/packages/sign_in_with_apple/android/src/main/kotlin/de/aboutyou/mobile/app/sign_in_with_apple/SignInWithApplePlugin.kt
+++ b/packages/sign_in_with_apple/android/src/main/kotlin/de/aboutyou/mobile/app/sign_in_with_apple/SignInWithApplePlugin.kt
@@ -47,7 +47,4 @@ public class SignInWithApplePlugin: FlutterPlugin, MethodCallHandler {
       }
     }
   }
-
-  override fun onDetachedFromEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {
-  }
 }


### PR DESCRIPTION
Caused the lib failing to compile on Android. 
Method was already declared on line 20