### PR TITLE
Fix Android main activity is recreated after processing the intent callback

### DIFF
--- a/packages/sign_in_with_apple/android/src/main/kotlin/com/aboutyou/dart_packages/sign_in_with_apple/SignInWithApplePlugin.kt
+++ b/packages/sign_in_with_apple/android/src/main/kotlin/com/aboutyou/dart_packages/sign_in_with_apple/SignInWithApplePlugin.kt
@@ -81,7 +81,7 @@ public class SignInWithApplePlugin: FlutterPlugin, MethodCallHandler, ActivityAw
         SignInWithApplePlugin.triggerMainActivityToHideChromeCustomTab = {
           val notificationIntent = _activity.getPackageManager().getLaunchIntentForPackage(_activity.getPackageName());
           notificationIntent.setPackage(null)
-          notificationIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED);
+          notificationIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
           _activity.startActivity(notificationIntent)
         }
 


### PR DESCRIPTION
I'm not sure if the call to close the chrome custom tab using FLAG_ACTIVITY_NEW_TASK + FLAG_ACTIVITY_RESET_TASK_IF_NEEDED flags was intended, but it was causing the flutter app to restart. Changing it to use FLAG_ACTIVITY_CLEAR_TOP solves the problem since it closes the chrome custom tab without recreating the main activity. This is related to the issue #81 