### PR TITLE
Handle the error user_cancelled_authorize

### DIFF
--- a/packages/sign_in_with_apple/lib/src/authorization_credential.dart
+++ b/packages/sign_in_with_apple/lib/src/authorization_credential.dart
@@ -156,6 +156,12 @@ AuthorizationCredentialAppleID parseAuthorizationCredentialAppleIDFromDeeplink(
   Uri deeplink,
 ) {
   if (deeplink.queryParameters.containsKey('error')) {
+    // In case the user canceled the sign-in, the URL will have an `error` parameter
+    // 
+    // The only error code that might be returned is `user_cancelled_authorize`, 
+    // which indicates that the user clicked the `Cancel` button during the web flow
+    //
+    // https://developer.apple.com/documentation/sign_in_with_apple/sign_in_with_apple_js/incorporating_sign_in_with_apple_into_other_platforms
     if (deeplink.queryParameters['error'] == 'user_cancelled_authorize') {
       throw SignInWithAppleAuthorizationException(
         code: AuthorizationErrorCode.canceled,

--- a/packages/sign_in_with_apple/lib/src/authorization_credential.dart
+++ b/packages/sign_in_with_apple/lib/src/authorization_credential.dart
@@ -159,7 +159,7 @@ AuthorizationCredentialAppleID parseAuthorizationCredentialAppleIDFromDeeplink(
     if (deeplink.queryParameters['error'] == 'user_cancelled_authorize') {
       throw SignInWithAppleAuthorizationException(
         code: AuthorizationErrorCode.canceled,
-        message: 'User canceled authorize',
+        message: 'User canceled authorization',
       );
     }
   }

--- a/packages/sign_in_with_apple/lib/src/authorization_credential.dart
+++ b/packages/sign_in_with_apple/lib/src/authorization_credential.dart
@@ -155,6 +155,15 @@ AuthorizationCredentialPassword parseAuthorizationCredentialPassword(
 AuthorizationCredentialAppleID parseAuthorizationCredentialAppleIDFromDeeplink(
   Uri deeplink,
 ) {
+  if (deeplink.queryParameters.containsKey('error')) {
+    if (deeplink.queryParameters['error'] == 'user_cancelled_authorize') {
+      throw SignInWithAppleAuthorizationException(
+        code: AuthorizationErrorCode.canceled,
+        message: 'User canceled authorize',
+      );
+    }
+  }
+
   final user = deeplink.queryParameters.containsKey('user')
       ? json.decode(deeplink.queryParameters['user']) as Map<String, dynamic>
       : null;


### PR DESCRIPTION
Handle the case when the user clicks on `Cancel` button on the last Apple web authentication flow screen. In this case, as stated on Apple docs at https://developer.apple.com/documentation/sign_in_with_apple/sign_in_with_apple_js/incorporating_sign_in_with_apple_into_other_platforms, the result redirect will have an `error` with code `user_cancelled_authorize`. Throws a `SignInWithAppleAuthorizationException` with `AuthorizationErrorCode.canceled` on that case.