### PR TITLE
Fix deeplink security issue

### DIFF
--- a/packages/sign_in_with_apple/CHANGELOG.md
+++ b/packages/sign_in_with_apple/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.5.1
 
-- Fix security deeplink issue which allowed to crash Flutter apps which have the `signinwithapple` plugin installed on Android ![#103](https://github.com/aboutyou/dart_packages/pull/103)
+- Fix security deeplink issue which allowed to crash Flutter apps which have the `signinwithapple` plugin installed on Android [#103](https://github.com/aboutyou/dart_packages/pull/103)
 
 ## 2.5.0
 

--- a/packages/sign_in_with_apple/CHANGELOG.md
+++ b/packages/sign_in_with_apple/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.5.1
 
-- Fix security deeplink issue which allowed to crash Flutter apps which have the `signinwithapple` plugin installed on Android [#103](https://github.com/aboutyou/dart_packages/pull/103)
+- Fix security deeplink issue which allowed to crash Flutter apps which have the `signinwithapple` plugin installed on Android ([#103](https://github.com/aboutyou/dart_packages/pull/103))
 
 ## 2.5.0
 

--- a/packages/sign_in_with_apple/CHANGELOG.md
+++ b/packages/sign_in_with_apple/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.5.1
+
+- Fix security deeplink issue which allowed to crash Flutter apps which have the `signinwithapple` plugin installed on Android ![#103](https://github.com/aboutyou/dart_packages/pull/103)
+
 ## 2.5.0
 
 - Properly handle the cancellation of the user from the web flow

--- a/packages/sign_in_with_apple/android/src/main/kotlin/com/aboutyou/dart_packages/sign_in_with_apple/SignInWithApplePlugin.kt
+++ b/packages/sign_in_with_apple/android/src/main/kotlin/com/aboutyou/dart_packages/sign_in_with_apple/SignInWithApplePlugin.kt
@@ -17,6 +17,8 @@ import io.flutter.plugin.common.PluginRegistry.ActivityResultListener
 import io.flutter.plugin.common.PluginRegistry.Registrar
 import io.flutter.Log
 
+val TAG = "SignInWithApple"
+
 /** SignInWithApplePlugin */
 public class SignInWithApplePlugin: FlutterPlugin, MethodCallHandler, ActivityAware, ActivityResultListener {
   private val CUSTOM_TABS_REQUEST_CODE = 1001;
@@ -142,7 +144,6 @@ public class SignInWithApplePlugin: FlutterPlugin, MethodCallHandler, ActivityAw
  * Activity which is used when the web-based authentication flow links back to the app
  *
  * DO NOT rename this or it's package name as it's configured in the consumer's `AndroidManifest.xml`
- *
  */
 public class SignInWithAppleCallback: Activity {
   constructor() : super()
@@ -159,7 +160,7 @@ public class SignInWithAppleCallback: Activity {
     } else {
       SignInWithApplePlugin.triggerMainActivityToHideChromeCustomTab = null
 
-      throw Exception("Received Sign in with Apple callback, but 'lastAuthorizationRequestResult' function was `null`")
+      Log.e(TAG, "Received Sign in with Apple callback, but 'lastAuthorizationRequestResult' function was `null`")
     }
 
     val triggerMainActivityToHideChromeCustomTab = SignInWithApplePlugin.triggerMainActivityToHideChromeCustomTab
@@ -167,7 +168,7 @@ public class SignInWithAppleCallback: Activity {
       triggerMainActivityToHideChromeCustomTab()
       SignInWithApplePlugin.triggerMainActivityToHideChromeCustomTab = null
     } else {
-      throw Exception("Received Sign in with Apple callback, but 'triggerMainActivityToHideChromeCustomTab' function was `null`")
+      Log.e(TAG, "Received Sign in with Apple callback, but 'triggerMainActivityToHideChromeCustomTab' function was `null`")
     }
 
     finish()

--- a/packages/sign_in_with_apple/example/pubspec.lock
+++ b/packages/sign_in_with_apple/example/pubspec.lock
@@ -136,7 +136,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.5.0"
+    version: "2.5.1"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/packages/sign_in_with_apple/pubspec.yaml
+++ b/packages/sign_in_with_apple/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sign_in_with_apple
 description: Flutter bridge to initiate Sign in with Apple (on iOS, macOS, and Android). Includes support for keychain entries as well as signing in with an Apple ID.
-version: 2.5.0
+version: 2.5.1
 homepage: https://github.com/aboutyou/dart_packages/tree/master/packages/sign_in_with_apple
 repository: https://github.com/aboutyou/dart_packages
 


### PR DESCRIPTION
Using 

```
adb shell am start -a "android.intent.action.VIEW" -d signinwithapple://
```

you are currently apple to crash any Flutter app which implements this `signinwithapple` scheme.