### PR TITLE
Added Semantics widget to SignInWithAppleButton

### DIFF
--- a/packages/sign_in_with_apple/lib/src/widgets/sign_in_with_apple_button.dart
+++ b/packages/sign_in_with_apple/lib/src/widgets/sign_in_with_apple_button.dart
@@ -166,25 +166,31 @@ class SignInWithAppleButton extends StatelessWidget {
         break;
     }
 
-    return Container(
-      height: height,
-      child: SizedBox.expand(
-        child: CupertinoButton(
-          borderRadius: borderRadius,
-          padding: EdgeInsets.zero,
-          color: _backgroundColor,
-          child: Container(
-            decoration: _decoration,
-            padding: EdgeInsets.symmetric(
-              horizontal: 16.0,
+    return Semantics(
+      button: true,
+      onTap: onPressed,
+      label: text,
+      enabled: onPressed != null,
+      child: Container(
+        height: height,
+        child: SizedBox.expand(
+          child: CupertinoButton(
+            borderRadius: borderRadius,
+            padding: EdgeInsets.zero,
+            color: _backgroundColor,
+            child: Container(
+              decoration: _decoration,
+              padding: EdgeInsets.symmetric(
+                horizontal: 16.0,
+              ),
+              height: height,
+              child: Row(
+                children: children,
+                mainAxisAlignment: MainAxisAlignment.center,
+              ),
             ),
-            height: height,
-            child: Row(
-              children: children,
-              mainAxisAlignment: MainAxisAlignment.center,
-            ),
+            onPressed: onPressed,
           ),
-          onPressed: onPressed,
         ),
       ),
     );


### PR DESCRIPTION
The `Semantics` widget is used by accessibility tools, search engines, and other semantic analysis software to determine the meaning of the application (for more information: https://api.flutter.dev/flutter/widgets/Semantics-class.html). So I added this to the `SignInWithAppleButton` to have this out-of-the-box support 👍