### PR TITLE
[sign_in_with_apple] Listen for credentialRevokedNotification event

### DIFF
--- a/packages/sign_in_with_apple/ios/Classes/SignInWithAppleAuthorizationHandler.swift
+++ b/packages/sign_in_with_apple/ios/Classes/SignInWithAppleAuthorizationHandler.swift
@@ -1,0 +1,36 @@
+import Foundation
+import Flutter
+import AuthenticationServices
+
+/*
+ A class that handles the case where during app use, if the user goes into the Settings app and
+ revokes Apple sign-in access.
+ */
+class SignInWithAppleAuthorizationHandler: NSObject, FlutterStreamHandler {
+
+    private var events: FlutterEventSink?
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink) -> FlutterError? {
+        if #available(iOS 13, *) {
+            self.events = events
+            NotificationCenter.default.addObserver(self, selector: #selector(onCredentialRevokedNotification), name: ASAuthorizationAppleIDProvider.credentialRevokedNotification, object: nil)
+        }
+        return nil
+    }
+
+    func onCancel(withArguments arguments: Any?) -> FlutterError? {
+        NotificationCenter.default.removeObserver(self)
+        self.events = nil
+        return nil
+    }
+
+    @available(iOS 13.0, *)
+    @objc
+    private func onCredentialRevokedNotification() {
+        self.events?(ASAuthorizationAppleIDProvider.credentialRevokedNotification)
+    }
+}

--- a/packages/sign_in_with_apple/ios/Classes/SwiftSignInWithApplePlugin.swift
+++ b/packages/sign_in_with_apple/ios/Classes/SwiftSignInWithApplePlugin.swift
@@ -8,10 +8,16 @@ public class SwiftSignInWithApplePlugin: NSObject, FlutterPlugin {
             name: methodChannelName,
             binaryMessenger: registrar.messenger()
         )
-        
+        let events = FlutterEventChannel(
+            name: eventChannelName,
+            binaryMessenger: registrar.messenger()
+        )
+
         if #available(iOS 13.0, *) {
             let instance = SignInWithAppleAvailablePlugin()
+            let handlerInstance = SignInWithAppleAuthorizationHandler()
             registrar.addMethodCallDelegate(instance, channel: channel)
+            events.setStreamHandler(handlerInstance)
         } else {
             let instance = SignInWithAppleUnavailablePlugin()
             registrar.addMethodCallDelegate(instance, channel: channel)

--- a/packages/sign_in_with_apple/lib/src/sign_in_with_apple.dart
+++ b/packages/sign_in_with_apple/lib/src/sign_in_with_apple.dart
@@ -16,14 +16,26 @@ import 'package:sign_in_with_apple/src/authorization_credential.dart'
 import 'package:sign_in_with_apple/src/credential_state.dart'
     show parseCredentialState;
 
-/// Wrapper class providing the methods to interact with Sign in with Apple.
 // ignore: avoid_classes_with_only_static_members
+/// Wrapper class providing the methods to interact with Sign in with Apple.
 class SignInWithApple {
   @visibleForTesting
   // ignore: public_member_api_docs
   static const channel = MethodChannel(
     'com.aboutyou.dart_packages.sign_in_with_apple',
   );
+
+  static const _eventChannel = EventChannel(
+    'com.aboutyou.dart_packages.sign_in_with_apple_events',
+  );
+
+  static Stream<void>? _onCredentialRevokedNotification;
+
+  /// Stream that sends an event when Apple ID credentials have been revoked.
+  static Stream<void> get onCredentialRevokedNotification {
+    _onCredentialRevokedNotification ??= _eventChannel.receiveBroadcastStream();
+    return _onCredentialRevokedNotification!;
+  }
 
   /// Returns the credentials stored in the Keychain for the website associated with the current app.
   ///

--- a/packages/sign_in_with_apple/test/sign_in_with_apple_test.dart
+++ b/packages/sign_in_with_apple/test/sign_in_with_apple_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sign_in_with_apple/sign_in_with_apple.dart';
 
@@ -57,5 +58,28 @@ void main() {
       await SignInWithApple.getKeychainCredential(),
       isA<AuthorizationCredentialPassword>(),
     );
+  });
+
+  // How to mock EventChannel notification
+  // https://github.com/flutter/flutter/issues/38954
+  test('onCredentialRevokedNotification -> Trigger notification', () async {
+    var count = 0;
+    void increment() {
+      count++;
+    }
+
+    SignInWithApple.onCredentialRevokedNotification.listen((event) {
+      increment();
+    });
+
+    expect(count, 0);
+
+    await ServicesBinding.instance?.defaultBinaryMessenger
+        .handlePlatformMessage(
+            'com.aboutyou.dart_packages.sign_in_with_apple_events',
+            StandardMethodCodec().encodeSuccessEnvelope(null),
+            (data) {});
+
+    expect(count, 1);
   });
 }


### PR DESCRIPTION
Add a stream to listen for `ASAuthorizationAppleIDProvider.credentialRevokedNotification` notification. This is to handle the case where the user revokes Apple sign-in access to the app during app use. Related to https://github.com/aboutyou/dart_packages/issues/180.