### PR TITLE
Prefer mavenCentral for Android builds.

### DIFF
--- a/packages/sign_in_with_apple/sign_in_with_apple/android/build.gradle
+++ b/packages/sign_in_with_apple/sign_in_with_apple/android/build.gradle
@@ -5,6 +5,7 @@ buildscript {
     ext.kotlin_version = '1.3.50'
     repositories {
         google()
+        mavenCentral()
         jcenter()
     }
 


### PR DESCRIPTION
https://blog.gradle.org/jcenter-shutdown

jcenter is shutting down and this can cause Android build failures in some regions immediately, and globally soon.