### PR TITLE
Enable capability for developer accounts

### DIFF
--- a/packages/sign_in_with_apple/sign_in_with_apple/README.md
+++ b/packages/sign_in_with_apple/sign_in_with_apple/README.md
@@ -232,3 +232,22 @@ The setup for macOS is mostly similar to iOS. As usual for Flutter development f
   - Ensure that "Sign in with Apple" is listed under the capabilities (if not, add it via the `+`)
   - Additionally there should be no warning on that screen. (For example your Mac must be registered for local development. (If not, you'll see a "one click fix" button to do so.))
 - In the terminal navigate back to the root of the `example` folder and `flutter run` on your test device
+
+### Enable For Developer Accounts
+
+If you want to enable capability using an Apple developer account, you need to add or create a `com.apple.developer.applesignin` entitlement - either through Xcode (see below) or by editing (or creating and adding to Xcode) `ios/Runner/Runner.entitlements` file.
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <!-- ... other keys -->
+  <key>com.apple.developer.applesignin</key>
+    <array>
+      <string>Default</string>
+    </array>
+  <!-- ... other keys -->
+</dict>
+</plist>
+```


### PR DESCRIPTION
Add `com.apple.developer.applesignin` (or with create `Runner.entitlements` file) to enabling capability for developer accounts.