### PR TITLE
Bugfix in Flutter v2.11.0 0.0.pre.632 (on master channel)

### DIFF
--- a/packages/sign_in_with_apple/sign_in_with_apple/CHANGELOG.md
+++ b/packages/sign_in_with_apple/sign_in_with_apple/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.3.0+1
+
+- Adjust overriding of `onActivityResult()` in `SignInWithApplePlugin.kt`.
+
 ## 3.3.0
 
 - Switch to `sign_in_with_apple_platform_interface` in conjunction with the addition of web support

--- a/packages/sign_in_with_apple/sign_in_with_apple/android/src/main/kotlin/com/aboutyou/dart_packages/sign_in_with_apple/SignInWithApplePlugin.kt
+++ b/packages/sign_in_with_apple/sign_in_with_apple/android/src/main/kotlin/com/aboutyou/dart_packages/sign_in_with_apple/SignInWithApplePlugin.kt
@@ -124,7 +124,7 @@ public class SignInWithApplePlugin: FlutterPlugin, MethodCallHandler, ActivityAw
     binding = null
   }
 
-  override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?): Boolean {
+  override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent): Boolean {
     if (requestCode == CUSTOM_TABS_REQUEST_CODE) {
       val _lastAuthorizationRequestResult = lastAuthorizationRequestResult
 

--- a/packages/sign_in_with_apple/sign_in_with_apple/pubspec.yaml
+++ b/packages/sign_in_with_apple/sign_in_with_apple/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sign_in_with_apple
 description: Flutter bridge to initiate Sign in with Apple (on iOS, macOS, and Android). Includes support for keychain entries as well as signing in with an Apple ID.
-version: 3.3.0
+version: 3.3.0+1
 homepage: https://github.com/aboutyou/dart_packages/tree/master/packages/sign_in_with_apple
 repository: https://github.com/aboutyou/dart_packages
 


### PR DESCRIPTION
With most recent version of Flutter, the `onActivityResult()` signature has changed -- the final argument `data` is now non-null. This pr fixes the problem.