### PR TITLE
Kotlin Version Error Resolution in Flutter v2.10.x Version - sign_in_with_apple

### DIFF
--- a/packages/sign_in_with_apple/sign_in_with_apple/android/build.gradle
+++ b/packages/sign_in_with_apple/sign_in_with_apple/android/build.gradle
@@ -2,7 +2,7 @@ group 'com.aboutyou.dart_packages.sign_in_with_apple'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.6.10'
     repositories {
         google()
         mavenCentral()

--- a/packages/sign_in_with_apple/sign_in_with_apple/example/android/build.gradle
+++ b/packages/sign_in_with_apple/sign_in_with_apple/example/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.6.10'
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
In the current flutter v2.10.x version, if the cotlin version is not more than a certain version, an error occurs and the application does not run normally.
To solve this problem, we updated the Kotiln version of the plug-in and example app and proceeded with the commit.