### PR TITLE
Remove `jcenter` repository and instead prefer Maven Central

### DIFF
--- a/packages/sign_in_with_apple/sign_in_with_apple/CHANGELOG.md
+++ b/packages/sign_in_with_apple/sign_in_with_apple/CHANGELOG.md
@@ -1,6 +1,10 @@
+## 4.2.0
+
+- Remove `jcenter` repository for the Android package
+
 ## 4.1.0
 
-- Add support for `transferred` credential state (XCode 13.3.1 support) 
+- Add support for `transferred` credential state (Xcode 13.3.1 support) 
 
 ## 4.0.0
 
@@ -12,11 +16,11 @@
 
 ## 3.2.0
 
-- Fix building macOS application with XCode 13 and macOS Big Sur
+- Fix building macOS application with Xcode 13 and macOS Big Sur
 
 ## 3.1.0
 
-- Add support for XCode 13
+- Add support for Xcode 13
 
 ## 3.0.0
 

--- a/packages/sign_in_with_apple/sign_in_with_apple/android/build.gradle
+++ b/packages/sign_in_with_apple/sign_in_with_apple/android/build.gradle
@@ -6,7 +6,6 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
 
     dependencies {
@@ -18,7 +17,7 @@ buildscript {
 rootProject.allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/packages/sign_in_with_apple/sign_in_with_apple/pubspec.yaml
+++ b/packages/sign_in_with_apple/sign_in_with_apple/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sign_in_with_apple
 description: Flutter bridge to initiate Sign in with Apple (on iOS, macOS, and Android). Includes support for keychain entries as well as signing in with an Apple ID.
-version: 4.1.0
+version: 4.2.0
 homepage: https://github.com/aboutyou/dart_packages/tree/master/packages/sign_in_with_apple
 repository: https://github.com/aboutyou/dart_packages
 


### PR DESCRIPTION
Follow up from https://github.com/aboutyou/dart_packages/pull/278

Fixes https://github.com/aboutyou/dart_packages/issues/337