### PR TITLE
[sign_in_with_apple] Fix `.toString()` method of SignInWithAppleAuthorizationException

### DIFF
--- a/packages/sign_in_with_apple/sign_in_with_apple_platform_interface/lib/exceptions.dart
+++ b/packages/sign_in_with_apple/sign_in_with_apple_platform_interface/lib/exceptions.dart
@@ -133,7 +133,7 @@ class SignInWithAppleAuthorizationException
   final String message;
 
   @override
-  String toString() => 'SignInWithAppleAuthorizationError($code, $message)';
+  String toString() => 'SignInWithAppleAuthorizationException($code, $message)';
 }
 
 class SignInWithAppleCredentialsException implements SignInWithAppleException {


### PR DESCRIPTION
## Description

The `SignInWithAppleAuthorizationException` class had the wrong `.toString` method.