### PR TITLE
Changed state and email fields to optional to match Apple's implementation

### DIFF
--- a/packages/sign_in_with_apple/sign_in_with_apple_web/lib/sign_in_with_apple_web.dart
+++ b/packages/sign_in_with_apple/sign_in_with_apple_web/lib/sign_in_with_apple_web.dart
@@ -112,11 +112,11 @@ extension type AuthorizationI._(JSObject _) implements JSObject {
   external String get code;
   @JS('id_token')
   external String get idToken;
-  external String get state;
+  external String? get state;
 }
 
 extension type UserI._(JSObject _) implements JSObject {
-  external String get email;
+  external String? get email;
   external NameI? get name;
 }
 


### PR DESCRIPTION
In this PR we updated the model objects to match Apple's responses.

# The Issue
We were getting errors with the library if we omitted the state parameter in our call to `getIDCredential` or we were hiding our email address in the Apple Sign-in dialog. The error was pretty obscure:
```
TypeError: Instance of '_TypeError': type '_TypeError' is not a subtype of type 'JSObject'
```

## What was actually happening
- We omitted the `state` parameter when calling `getIDCredential` and then hid the email in the Apple Sign-in dialog
- The `state` and / or `email` fields were omitted in the JS response from Apple
- `toDart` [here](https://github.com/aboutyou/dart_packages/blob/adbfcf5cdb9a9614978b9074dfca8dba8b271cdd/packages/sign_in_with_apple/sign_in_with_apple_web/lib/sign_in_with_apple_web.dart#L48) could not parse the JS object because the `state` and `email` fields were defined as required parameters and not optionals in `UserI` and `AuthorizationI`
- An informative parsing error was raised:
```
TypeError: null: type 'Null' is not a subtype of type 'String'
```
- The catch block is only accounting for errors coming from Apple when trying to convert the error to `SignInErrorI` [here](https://github.com/aboutyou/dart_packages/blob/adbfcf5cdb9a9614978b9074dfca8dba8b271cdd/packages/sign_in_with_apple/sign_in_with_apple_web/lib/sign_in_with_apple_web.dart#L59-L67)
- This failed, so another error was raised:
```
TypeError: Instance of '_TypeError': type '_TypeError' is not a subtype of type 'JSObject'
```
- This obscured the original informative error message

# The solution
- `state` field has been updated to be optional: `state` is defined as optional when calling `getIDCredential` [here](https://github.com/aboutyou/dart_packages/blob/adbfcf5cdb9a9614978b9074dfca8dba8b271cdd/packages/sign_in_with_apple/sign_in_with_apple/lib/src/sign_in_with_apple.dart#L54-L72). When not passing it, Apple will omit it in their response, thus it should be an optional field on `AuthorizationI`.

- `email` field has been updated to optional: In various circumstances (ex. when the user uses Apple sign-in with their email hidden) this field might be omitted in the response from Apple. Thus this should also be defined as optional in `UserI`.

# Couple of questions remain
- Should we do the same for [`name.firstName`](https://developer.apple.com/documentation/sign_in_with_apple/namei/3530378-firstname) and [`name.lastName`](https://developer.apple.com/documentation/sign_in_with_apple/namei/3530379-lastname)?
So far we were not about to clear any of these fields so it seems they are always provided, however it's hard to know we really covered all edge cases.
- Should we improve the code in the catch block [here](https://github.com/aboutyou/dart_packages/blob/adbfcf5cdb9a9614978b9074dfca8dba8b271cdd/packages/sign_in_with_apple/sign_in_with_apple_web/lib/sign_in_with_apple_web.dart#L59-L67) so if parsing errors in the future arise we get more informative error messages and can fix them quicker?