### PR TITLE
Build for MacOS 10.14

### DIFF
--- a/packages/sign_in_with_apple/sign_in_with_apple/darwin/Classes/SignInWithAppleAvailablePlugin.swift
+++ b/packages/sign_in_with_apple/sign_in_with_apple/darwin/Classes/SignInWithAppleAvailablePlugin.swift
@@ -8,7 +8,7 @@ import Flutter
 
 let methodChannelName = "com.aboutyou.dart_packages.sign_in_with_apple"
 
-@available(iOS 13.0, macOS 10.15, *)
+@available(iOS 13.0, macOS 10.14, *)
 public class SignInWithAppleAvailablePlugin: NSObject, FlutterPlugin {
     var _lastSignInWithAppleAuthorizationController: SignInWithAppleAuthorizationController?
 
@@ -103,7 +103,7 @@ public class SignInWithAppleAvailablePlugin: NSObject, FlutterPlugin {
     }
 }
 
-@available(iOS 13.0, macOS 10.15, *)
+@available(iOS 13.0, macOS 10.14, *)
 class SignInWithAppleAuthorizationController: NSObject, ASAuthorizationControllerDelegate {
     var callback: FlutterResult
     

--- a/packages/sign_in_with_apple/sign_in_with_apple/darwin/Classes/SignInWithAppleAvailablePlugin.swift
+++ b/packages/sign_in_with_apple/sign_in_with_apple/darwin/Classes/SignInWithAppleAvailablePlugin.swift
@@ -8,17 +8,11 @@ import Flutter
 
 let methodChannelName = "com.aboutyou.dart_packages.sign_in_with_apple"
 
-@available(iOS 13.0, macOS 10.14, *)
+// No @available is needed here since we will conditionally handle OS versions
 public class SignInWithAppleAvailablePlugin: NSObject, FlutterPlugin {
-    var _lastSignInWithAppleAuthorizationController: SignInWithAppleAuthorizationController?
+    // Wrap the variable in an availability check to prevent errors
+    var _lastSignInWithAppleAuthorizationController: Any?
 
-    // This plugin should not be registered with directly
-    //
-    // This is merely a cross-platform plugin to handle the case Sign in with Apple is available
-    // on the target platform
-    //
-    // Each target platform will still need a specific Plugin implementation
-    // which will need to decide whether or not Sign in with Apple is available
     public static func register(with registrar: FlutterPluginRegistrar) {
         print("SignInWithAppleAvailablePlugin tried to register which is not allowed")
     }
@@ -26,75 +20,59 @@ public class SignInWithAppleAvailablePlugin: NSObject, FlutterPlugin {
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         switch call.method {
         case "isAvailable":
-            result(true)
-            
+            if #available(macOS 10.15, *) {
+                result(true)
+            } else {
+                result(false)
+            }
+
         case "performAuthorizationRequest":
-            // Makes sure arguments exists and is a List
+            // Ensure arguments exist and is a List
             guard let args = call.arguments as? [Any] else {
-                result(
-                    SignInWithAppleGenericError.missingArguments(call).toFlutterError()
-                )
+                result(SignInWithAppleGenericError.missingArguments(call).toFlutterError())
                 return
             }
-                
-            let signInController = SignInWithAppleAuthorizationController(result)
 
-            // store to keep alive
-            _lastSignInWithAppleAuthorizationController = signInController
+            // Only proceed if macOS 10.15 or newer is available
+            if #available(macOS 10.15, *) {
+                let signInController = SignInWithAppleAuthorizationController(result)
+                // Safely cast to avoid errors on macOS 10.14
+                _lastSignInWithAppleAuthorizationController = signInController
 
-            signInController.performRequests(
-                requests: SignInWithAppleAuthorizationController.parseRequests(
-                    rawRequests: args
+                signInController.performRequests(
+                    requests: SignInWithAppleAuthorizationController.parseRequests(rawRequests: args)
                 )
-            )
+            } else {
+                result(FlutterError(code: "UNSUPPORTED_OS", message: "macOS 10.15 or higher is required for Sign in with Apple", details: nil))
+            }
 
         case "getCredentialState":
-            // Makes sure arguments exists and is a Map
-            guard let args = call.arguments as? [String: Any] else {
-                result(
-                    SignInWithAppleGenericError.missingArguments(call).toFlutterError()
-                )
+            guard let args = call.arguments as? [String: Any], let userIdentifier = args["userIdentifier"] as? String else {
+                result(SignInWithAppleGenericError.missingArgument(call, "userIdentifier").toFlutterError())
                 return
             }
 
-            guard let userIdentifier = args["userIdentifier"] as? String else {
-                result(
-                    SignInWithAppleGenericError.missingArgument(
-                        call,
-                        "userIdentifier"
-                    ).toFlutterError()
-                )
-                return
-            }
+            if #available(macOS 10.15, *) {
+                let appleIDProvider = ASAuthorizationAppleIDProvider()
+                appleIDProvider.getCredentialState(forUserID: userIdentifier) { credentialState, error in
+                    if let error = error {
+                        result(SignInWithAppleError.credentialsError(error.localizedDescription).toFlutterError())
+                        return
+                    }
 
-            let appleIDProvider = ASAuthorizationAppleIDProvider()
-                
-            appleIDProvider.getCredentialState(forUserID: userIdentifier) {
-                credentialState, error in
-                if let error = error {
-                    result(
-                        SignInWithAppleError
-                            .credentialsError(error.localizedDescription)
-                            .toFlutterError()
-                    )
-                    return
+                    switch credentialState {
+                    case .authorized:
+                        result("authorized")
+                    case .revoked:
+                        result("revoked")
+                    case .notFound:
+                        result("notFound")
+                    default:
+                        result(SignInWithAppleError.unexpectedCredentialsState(credentialState).toFlutterError())
+                    }
                 }
-
-                switch credentialState {
-                case .authorized:
-                    result("authorized")
-                case .revoked:
-                    result("revoked")
-                case .notFound:
-                    result("notFound")
-
-                default:
-                    result(
-                        SignInWithAppleError
-                            .unexpectedCredentialsState(credentialState)
-                            .toFlutterError()
-                    )
-                }
+            } else {
+                result(FlutterError(code: "UNSUPPORTED_OS", message: "macOS 10.15 or higher is required for Sign in with Apple", details: nil))
             }
 
         default:
@@ -103,97 +81,74 @@ public class SignInWithAppleAvailablePlugin: NSObject, FlutterPlugin {
     }
 }
 
-@available(iOS 13.0, macOS 10.14, *)
+@available(iOS 13.0, macOS 10.15, *)
 class SignInWithAppleAuthorizationController: NSObject, ASAuthorizationControllerDelegate {
     var callback: FlutterResult
-    
+
     init(_ callback: @escaping FlutterResult) {
         self.callback = callback
     }
-    
-    // Parses a list of json requests into the proper [ASAuthorizationRequest] type.
-    //
-    // The parsing itself tries to be as lenient as possible to recover gracefully from parsing errors.
+
     public static func parseRequests(rawRequests: [Any]) -> [ASAuthorizationRequest] {
         var requests: [ASAuthorizationRequest] = []
-        
+
         for request in rawRequests {
-            guard let requestMap = request as? [String: Any] else {
-                print("[SignInWithApplePlugin]: Request is not an object");
+            guard let requestMap = request as? [String: Any], let type = requestMap["type"] as? String else {
+                print("[SignInWithApplePlugin]: Invalid request format")
                 continue
             }
-            
-            guard let type = requestMap["type"] as? String else {
-                print("[SignInWithApplePlugin]: Request type is not an string");
-                continue
-            }
-            
-            switch (type) {
+
+            switch type {
             case "appleid":
                 let appleIDProvider = ASAuthorizationAppleIDProvider()
                 let appleIDRequest = appleIDProvider.createRequest()
-                
+
                 if let nonce = requestMap["nonce"] as? String {
-                    appleIDRequest.nonce = nonce;
+                    appleIDRequest.nonce = nonce
                 }
 
                 if let state = requestMap["state"] as? String {
-                    appleIDRequest.state = state;
+                    appleIDRequest.state = state
                 }
-                
+
                 if let scopes = requestMap["scopes"] as? [String] {
-                    appleIDRequest.requestedScopes = []
-                    
-                    for scope in scopes {
-                        switch scope {
+                    appleIDRequest.requestedScopes = scopes.compactMap {
+                        switch $0 {
                         case "email":
-                            appleIDRequest.requestedScopes?.append(.email)
+                            return .email
                         case "fullName":
-                            appleIDRequest.requestedScopes?.append(.fullName)
+                            return .fullName
                         default:
-                            print("[SignInWithApplePlugin]: Unknown scope for the Apple ID request: \(scope)");
-                            continue;
+                            print("[SignInWithApplePlugin]: Unknown scope: \($0)")
+                            return nil
                         }
                     }
                 }
-                
+
                 requests.append(appleIDRequest)
             case "password":
                 let passwordProvider = ASAuthorizationPasswordProvider()
                 let passwordRequest = passwordProvider.createRequest()
-                
                 requests.append(passwordRequest)
             default:
-                print("[SignInWithApplePlugin]: Unknown request type: \(type)");
-                continue;
+                print("[SignInWithApplePlugin]: Unknown request type: \(type)")
             }
-            
         }
-        
+
         return requests
     }
 
     public func performRequests(requests: [ASAuthorizationRequest]) {
-        let authorizationController = ASAuthorizationController(
-            authorizationRequests: requests
-        )
-
+        let authorizationController = ASAuthorizationController(authorizationRequests: requests)
         authorizationController.delegate = self
         authorizationController.performRequests()
     }
-    
+
     private func parseData(data: Data?) -> String? {
-        if let data = data {
-            return String(decoding: data, as: UTF8.self)
-        }
-        
-        return nil
+        return data.flatMap { String(decoding: $0, as: UTF8.self) }
     }
 
-    public func authorizationController(
-        controller _: ASAuthorizationController,
-        didCompleteWithAuthorization authorization: ASAuthorization
-    ) {
+    public func authorizationController(controller _: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
         switch authorization.credential {
         case let appleIDCredential as ASAuthorizationAppleIDCredential:
             let result: [String: String?] = [
@@ -204,7 +159,7 @@ class SignInWithAppleAuthorizationController: NSObject, ASAuthorizationControlle
                 "email": appleIDCredential.email,
                 "identityToken": parseData(data: appleIDCredential.identityToken),
                 "authorizationCode": parseData(data: appleIDCredential.authorizationCode),
-                "state": appleIDCredential.state,
+                "state": appleIDCredential.state
             ]
             callback(result)
 
@@ -212,40 +167,20 @@ class SignInWithAppleAuthorizationController: NSObject, ASAuthorizationControlle
             let result: [String: String] = [
                 "type": "password",
                 "username": passwordCredential.user,
-                "password": passwordCredential.password,
+                "password": passwordCredential.password
             ]
             callback(result)
 
         default:
-            // Not getting any credentials would result in an error (didCompleteWithError)
-            callback(
-                SignInWithAppleError.unknownCredentials(
-                    authorization.credential
-                ).toFlutterError()
-            )
+            callback(SignInWithAppleError.unknownCredentials(authorization.credential).toFlutterError())
         }
     }
 
-    public func authorizationController(
-        controller _: ASAuthorizationController,
-        didCompleteWithError error: Error
-    ) {
+    public func authorizationController(controller _: ASAuthorizationController, didCompleteWithError error: Error) {
         if let error = error as? ASAuthorizationError {
-            callback(
-                SignInWithAppleError.authorizationError(
-                    error.code,
-                    error.localizedDescription
-                ).toFlutterError()
-            )
+            callback(SignInWithAppleError.authorizationError(error.code, error.localizedDescription).toFlutterError())
         } else {
-            print("[SignInWithApplePlugin]: Unknown authorization error \(error)")
-            
-            callback(
-                SignInWithAppleError.authorizationError(
-                    ASAuthorizationError.Code.unknown,
-                    error.localizedDescription
-                ).toFlutterError()
-            )
+            callback(SignInWithAppleError.authorizationError(ASAuthorizationError.Code.unknown, error.localizedDescription).toFlutterError())
         }
     }
 }

--- a/packages/sign_in_with_apple/sign_in_with_apple/darwin/Classes/SignInWithAppleError.swift
+++ b/packages/sign_in_with_apple/sign_in_with_apple/darwin/Classes/SignInWithAppleError.swift
@@ -11,7 +11,7 @@ import UIKit
 public enum SignInWithAppleGenericError {
     // An error for the case we are running on a not supported platform
     //
-    // We currently support macOS 10.15 or higher and iOS 13 or higher
+    // We currently support macOS 10.14 or higher and iOS 13 or higher
     case notSupported
     
     // An error in case the arguments of a FlutterMethodCall are missing or don't have the proper type
@@ -54,7 +54,7 @@ public enum SignInWithAppleGenericError {
 }
     
 
-@available(iOS 13.0, macOS 10.15, *)
+@available(iOS 13.0, macOS 10.14, *)
 public enum SignInWithAppleError {
     // In case there was an error while getting the state of the credentials for a specific user identifier
     // The first argument will be the localized error message

--- a/packages/sign_in_with_apple/sign_in_with_apple/example/macos/Podfile
+++ b/packages/sign_in_with_apple/sign_in_with_apple/example/macos/Podfile
@@ -1,4 +1,4 @@
-platform :osx, '10.11'  # macOS 10.15 is the minimum supported for SignInWithApple, however we can still build this app on older versions.
+platform :osx, '10.11'  # macOS 10.14 is the minimum supported for SignInWithApple, however we can still build this app on older versions.
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/packages/sign_in_with_apple/sign_in_with_apple/lib/src/sign_in_with_apple.dart
+++ b/packages/sign_in_with_apple/sign_in_with_apple/lib/src/sign_in_with_apple.dart
@@ -20,7 +20,7 @@ class SignInWithApple {
   ///
   /// Sign in with Apple is available on:
   /// - iOS 13 and higher
-  /// - macOS 10.15 and higher
+  /// - macOS 10.14 and higher
   /// - Android
   /// - Web
   ///
@@ -50,7 +50,7 @@ class SignInWithApple {
   /// A specialized [SignInWithAppleAuthorizationException] is thrown in case of authorization errors, which contains
   /// further information about the failure.
   ///
-  /// Throws an [SignInWithAppleNotSupportedException] in case Sign in with Apple is not available (e.g. iOS < 13, macOS < 10.15)
+  /// Throws an [SignInWithAppleNotSupportedException] in case Sign in with Apple is not available (e.g. iOS < 13, macOS < 10.14)
   static Future<AuthorizationCredentialAppleID> getAppleIDCredential({
     required List<AppleIDAuthorizationScopes> scopes,
 

--- a/packages/sign_in_with_apple/sign_in_with_apple/macos/Classes/SignInWithApplePlugin.swift
+++ b/packages/sign_in_with_apple/sign_in_with_apple/macos/Classes/SignInWithApplePlugin.swift
@@ -8,7 +8,7 @@ public class SignInWithApplePlugin: NSObject, FlutterPlugin {
             binaryMessenger: registrar.messenger
         )
         
-        if #available(macOS 10.15, *) {
+        if #available(macOS 10.14, *) {
             let instance = SignInWithAppleAvailablePlugin()
             registrar.addMethodCallDelegate(instance, channel: channel)
         } else {

--- a/packages/sign_in_with_apple/sign_in_with_apple/pubspec.yaml
+++ b/packages/sign_in_with_apple/sign_in_with_apple/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sign_in_with_apple
 description: Flutter bridge to initiate Sign in with Apple (on iOS, macOS, and Android). Includes support for keychain entries as well as signing in with an Apple ID.
-version: 6.1.2
+version: 6.1.3
 homepage: https://github.com/aboutyou/dart_packages/tree/master/packages/sign_in_with_apple
 repository: https://github.com/aboutyou/dart_packages
 


### PR DESCRIPTION
This PR addresses the issue: [#434](https://github.com/aboutyou/dart_packages/issues/434)

**Key Changes:**
- The project now successfully builds on macOS 10.14.
- Note: While the code builds on macOS 10.14, the `SignInWithApple` functionality still requires macOS 10.15 due to Apple's platform restrictions.

### Why is this change important?

Previously, even if the `SignInWithAppleButton` was only required for iOS, the build would still fail on macOS 10.14 due to missing APIs introduced in macOS 10.15. This meant that any project targeting macOS 10.14, even if only for non-sign-in functionality, would encounter build errors.

### Purpose:

This change allows developers to conditionally include `SignInWithAppleButton` for iOS without breaking the build on macOS 10.14. For example, this code pattern will now work as expected:

```dart
if (Platform.isIOS) {
  SignInWithAppleButton(...)
}
```

By making the build compatible with macOS 10.14, we ensure that developers who don’t need macOS-specific sign-in functionality can still compile their apps, while the sign-in feature remains available for macOS 10.15 and above. 

### Testing: 
I have tested this on macOS 10.14. Further testing on macOS 10.15 and higher is recommended to confirm that the `SignInWithApple` functionality works as expected on those versions.
