### PR TITLE
Deeplink query paramerters user details validation improvment

### DIFF
--- a/packages/sign_in_with_apple/sign_in_with_apple_platform_interface/lib/authorization_credential.dart
+++ b/packages/sign_in_with_apple/sign_in_with_apple_platform_interface/lib/authorization_credential.dart
@@ -160,7 +160,8 @@ AuthorizationCredentialAppleID parseAuthorizationCredentialAppleIDFromDeeplink(
     }
   }
 
-  final user = deeplink.queryParameters.containsKey('user')
+  final user = deeplink.queryParameters.containsKey('user') &&
+          deeplink.queryParameters['user']?.isNotEmpty == true
       ? json.decode(deeplink.queryParameters['user'] as String)
           as Map<String, dynamic>
       : null;


### PR DESCRIPTION
Added validation to the user object received via the deep link. It already checks for the presence of the user object, but it could still be empty in sign-in scenarios and interrupt the sign-in flow due to JSON decode error.