### PR TITLE
Ensure Thread-Safe Handling of Authorization Requests in SignInWithApplePlugin

### DIFF
--- a/packages/sign_in_with_apple/sign_in_with_apple/android/src/main/kotlin/com/aboutyou/dart_packages/sign_in_with_apple/SignInWithApplePlugin.kt
+++ b/packages/sign_in_with_apple/sign_in_with_apple/android/src/main/kotlin/com/aboutyou/dart_packages/sign_in_with_apple/SignInWithApplePlugin.kt
@@ -39,6 +39,7 @@ public class SignInWithApplePlugin: FlutterPlugin, MethodCallHandler, ActivityAw
   companion object {
     var lastAuthorizationRequestResult: Result? = null
     var triggerMainActivityToHideChromeCustomTab : (() -> Unit)? = null
+    val authorizationLock = Any()
   }
 
   override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {
@@ -109,13 +110,15 @@ public class SignInWithApplePlugin: FlutterPlugin, MethodCallHandler, ActivityAw
 
   override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?): Boolean {
     if (requestCode == CUSTOM_TABS_REQUEST_CODE) {
-      val _lastAuthorizationRequestResult = lastAuthorizationRequestResult
+      synchronized(authorizationLock) {
+        val _lastAuthorizationRequestResult = lastAuthorizationRequestResult
 
-      if (_lastAuthorizationRequestResult != null) {
-        _lastAuthorizationRequestResult.error("authorization-error/canceled", "The user closed the Custom Tab", null)
+        if (_lastAuthorizationRequestResult != null) {
+          _lastAuthorizationRequestResult.error("authorization-error/canceled", "The user closed the Custom Tab", null)
 
-        lastAuthorizationRequestResult = null
-        triggerMainActivityToHideChromeCustomTab = null
+          lastAuthorizationRequestResult = null
+          triggerMainActivityToHideChromeCustomTab = null
+        }
       }
     }
 
@@ -134,24 +137,26 @@ public class SignInWithAppleCallback: Activity {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
 
-    // Note: The order is important here, as we first need to send the data to Flutter and then close the custom tab
-    // That way we can detect a manually closed tab in `SignInWithApplePlugin.onActivityResult` (by detecting that we're still waiting on data)
-    val lastAuthorizationRequestResult = SignInWithApplePlugin.lastAuthorizationRequestResult
-    if (lastAuthorizationRequestResult != null) {
-      lastAuthorizationRequestResult.success(intent?.data?.toString())
-      SignInWithApplePlugin.lastAuthorizationRequestResult = null
-    } else {
-      SignInWithApplePlugin.triggerMainActivityToHideChromeCustomTab = null
+    synchronized(SignInWithApplePlugin.authorizationLock) {
+      // Note: The order is important here, as we first need to send the data to Flutter and then close the custom tab
+      // That way we can detect a manually closed tab in `SignInWithApplePlugin.onActivityResult` (by detecting that we're still waiting on data)
+      val lastAuthorizationRequestResult = SignInWithApplePlugin.lastAuthorizationRequestResult
+      if (lastAuthorizationRequestResult != null) {
+        lastAuthorizationRequestResult.success(intent?.data?.toString())
+        SignInWithApplePlugin.lastAuthorizationRequestResult = null
+      } else {
+        SignInWithApplePlugin.triggerMainActivityToHideChromeCustomTab = null
 
-      Log.e(TAG, "Received Sign in with Apple callback, but 'lastAuthorizationRequestResult' function was `null`")
-    }
+        Log.e(TAG, "Received Sign in with Apple callback, but 'lastAuthorizationRequestResult' function was `null`")
+      }
 
-    val triggerMainActivityToHideChromeCustomTab = SignInWithApplePlugin.triggerMainActivityToHideChromeCustomTab
-    if (triggerMainActivityToHideChromeCustomTab != null) {
-      triggerMainActivityToHideChromeCustomTab()
-      SignInWithApplePlugin.triggerMainActivityToHideChromeCustomTab = null
-    } else {
-      Log.e(TAG, "Received Sign in with Apple callback, but 'triggerMainActivityToHideChromeCustomTab' function was `null`")
+      val triggerMainActivityToHideChromeCustomTab = SignInWithApplePlugin.triggerMainActivityToHideChromeCustomTab
+      if (triggerMainActivityToHideChromeCustomTab != null) {
+        triggerMainActivityToHideChromeCustomTab()
+        SignInWithApplePlugin.triggerMainActivityToHideChromeCustomTab = null
+      } else {
+        Log.e(TAG, "Received Sign in with Apple callback, but 'triggerMainActivityToHideChromeCustomTab' function was `null`")
+      }
     }
 
     finish()


### PR DESCRIPTION
This PR introduces improvements to the thread-safety of the `SignInWithApplePlugin` by ensuring that the `authorizationLock` is shared across all plugin instances.

### Key changes include

- Declared authorizationLock to the companion object to make it static and shared across all requests.
- Add synchronized blocks and used the static authorizationLock for consistent synchronization.
- Ensured proper handling of shared resources (lastAuthorizationRequestResult and triggerMainActivityToHideChromeCustomTab) to prevent race conditions.

### Testing

- Verified that multiple simultaneous authorization requests are handled safely without conflicts.
- Tested edge cases, including user cancellation and app restarts during the authorization flow.
- These changes ensure that the plugin behaves reliably in multi-threaded environments and prevents potential crashes caused by race conditions.

Closes #458
