### PR TITLE
[sign_in_with_apple]: Prepare 8.0.0 release

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -20,7 +20,6 @@ jobs:
         package:
           [
             pending_operations,
-            sign_in_with_apple/sign_in_with_apple,
             sign_in_with_apple/sign_in_with_apple_platform_interface,
             state_queue_test,
             state_queue,
@@ -54,20 +53,55 @@ jobs:
           name: ${{ matrix.package }}
           fail_ci_if_error: false
 
+  test-siwa:
+    name: Test ${{ matrix.package }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, macos-15]
+        package: [sign_in_with_apple/sign_in_with_apple]
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-java@v1
+        with:
+          java-version: "12.x"
+      - uses: subosito/flutter-action@4389e6cbc6cb8a4b18c628ff96ff90be0e926aa8 # v1.5.3
+        with:
+          flutter-version: "3.41.0"
+      - name: Install dependencies
+        run: flutter packages get
+        working-directory: packages/${{ matrix.package }}
+      - name: Analyze
+        run: flutter analyze
+        working-directory: packages/${{ matrix.package }}
+      - name: Format
+        run: dart format --set-exit-if-changed .
+        working-directory: packages/${{ matrix.package }}
+      - name: Run tests
+        run: flutter test --coverage
+        working-directory: packages/${{ matrix.package }}
+      - name: Upload coverage to Codecov
+        if: startsWith(matrix.os, 'macos')
+        uses: codecov/codecov-action@v1.0.6
+        with:
+          flags: ${{ matrix.package }}
+          name: ${{ matrix.package }}
+          fail_ci_if_error: false
+
   build-ios:
-    name: Build ${{ matrix.package }} iOS on ${{ matrix.os }} with Xcode ${{ matrix.xcode }} and Flutter ${{ matrix.flutter }}
+    name: Build ${{ matrix.package }} iOS on ${{ matrix.os }} with Xcode ${{ matrix.xcode }} and Flutter ${{ matrix.flutter }} with Cocoapods (default)
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [macos-15, macos-26]
         package: [sign_in_with_apple/sign_in_with_apple]
         xcode: ["16.4", "26.1.1"]
-        flutter: ["3.35.0", "3.38.4"]
+        flutter: ["3.41.9"]
         exclude:
           - os: macos-15
             xcode: 26.1.1
-          - os: macos-15
-            flutter: 3.35.0
+          - os: macos-26
+            xcode: 16.4
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-java@v1
@@ -95,12 +129,14 @@ jobs:
         os: [macos-15, macos-26]
         package: [sign_in_with_apple/sign_in_with_apple]
         xcode: ["16.4", "26.1.1"]
-        flutter: ["3.35.0", "3.38.4"]
+        flutter: ["3.41.0", "3.41.9"]
         exclude:
-          - xcode: 16.4
-            flutter: 3.35.0
           - os: macos-15
             xcode: 26.1.1
+          - os: macos-26
+            xcode: 16.4
+          - os: macos-15
+            flutter: 3.41.0
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-java@v1
@@ -145,7 +181,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04]
         package: [sign_in_with_apple/sign_in_with_apple]
-        flutter: ["3.35.0"]
+        flutter: ["3.41.9"]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-java@v2
@@ -160,17 +196,19 @@ jobs:
         working-directory: packages/${{ matrix.package }}/example
 
   build-macos:
-    name: Build ${{ matrix.package }} macOS on ${{ matrix.os }} with Xcode ${{ matrix.xcode }} and Flutter ${{ matrix.flutter }}
+    name: Build ${{ matrix.package }} macOS on ${{ matrix.os }} with Xcode ${{ matrix.xcode }} and Flutter ${{ matrix.flutter }} with Cocoapods
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [macos-15, macos-26]
         package: [sign_in_with_apple/sign_in_with_apple]
         xcode: ["16.4", "26.1.1"]
-        flutter: ["3.35.0"]
+        flutter: ["3.41.9"]
         exclude:
           - os: macos-15
             xcode: 26.1.1
+          - os: macos-26
+            xcode: 16.4
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-java@v1
@@ -192,6 +230,52 @@ jobs:
           OTHER_SWIFT_FLAGS: "-warnings-as-errors"
           DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer
 
+  build-macos-spm:
+    name: Build ${{ matrix.package }} macOS on ${{ matrix.os }} with Xcode ${{ matrix.xcode }} and Flutter ${{ matrix.flutter }} with SPM
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-26]
+        package: [sign_in_with_apple/sign_in_with_apple]
+        xcode: ["26.1.1"]
+        flutter: ["3.41.9"]
+        exclude:
+          - os: macos-15
+            xcode: 26.1.1
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-java@v1
+        with:
+          java-version: "12.x"
+      - name: Xcode select
+        run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
+      - uses: subosito/flutter-action@4389e6cbc6cb8a4b18c628ff96ff90be0e926aa8 # v1.5.3
+        with:
+          flutter-version: ${{ matrix.flutter }}
+      - name: Enable macOS Desktop Integration
+        run: flutter config --enable-macos-desktop
+      - name: Flutter doctor (version check)
+        run: flutter doctor
+      - name: Enable SPM support
+        run: flutter config --enable-swift-package-manager
+        working-directory: packages/${{ matrix.package }}/example
+      - name: List dependency config before (debug)
+        run: |
+          less macos/Runner.xcodeproj/project.pbxproj | grep Pods || echo ""
+          less macos/Runner.xcodeproj/project.pbxproj | grep FlutterGeneratedPluginSwiftPackage || echo ""
+        working-directory: packages/${{ matrix.package }}/example
+      - name: Remove Cocoapods from project
+        run: pod deintegrate
+        working-directory: packages/${{ matrix.package }}/example/macos
+      - name: Remove Cocoapods files
+        run: rm -rf Pod*
+        working-directory: packages/${{ matrix.package }}/example/macos
+      - name: Build macOS
+        run: flutter build macos
+        working-directory: packages/${{ matrix.package }}/example
+        env:
+          DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer
+
   build-web:
     name: Build ${{ matrix.package }} Web on ${{ matrix.os }} and Flutter ${{ matrix.flutter }}
     runs-on: ${{ matrix.os }}
@@ -199,7 +283,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04]
         package: [sign_in_with_apple/sign_in_with_apple]
-        flutter: ["3.35.0"]
+        flutter: ["3.41.9"]
     steps:
       - uses: actions/checkout@v1
       - uses: subosito/flutter-action@4389e6cbc6cb8a4b18c628ff96ff90be0e926aa8 # v1.5.3

--- a/packages/sign_in_with_apple/sign_in_with_apple/CHANGELOG.md
+++ b/packages/sign_in_with_apple/sign_in_with_apple/CHANGELOG.md
@@ -1,3 +1,10 @@
+### 8.0.0
+
+- Support Swift Package Manager (SPM) [#470](https://github.com/aboutyou/dart_packages/pull/470)/[#471](https://github.com/aboutyou/dart_packages/pull/471)
+- Set min Flutter SDK to 3.41.0
+  - The `SignInWithAppleButton`'s icon alignment is now called `SignInWithAppleIconAlignment` to avoid conflicting with the Material `IconAlignment`
+  - Support Xcode 26.1.1 (while still supporting Xcode 16.4 as our minimum)
+
 ## 7.0.1
 
 - Allow `null` for `SignInWithAppleButton`'s `onPressed` handler to disable it
@@ -53,7 +60,7 @@
 
 ## 4.1.0
 
-- Add support for `transferred` credential state (Xcode 13.3.1 support) 
+- Add support for `transferred` credential state (Xcode 13.3.1 support)
 
 ## 4.0.0
 

--- a/packages/sign_in_with_apple/sign_in_with_apple/darwin/sign_in_with_apple/Package.swift
+++ b/packages/sign_in_with_apple/sign_in_with_apple/darwin/sign_in_with_apple/Package.swift
@@ -6,17 +6,21 @@ import PackageDescription
 let package = Package(
     name: "sign_in_with_apple",
     platforms: [
-        .iOS("12.0"),
-        .macOS("10.14")
+        .iOS("13.0"),
+        .macOS("10.15"),
     ],
     products: [
         .library(name: "sign-in-with-apple", targets: ["sign_in_with_apple"])
     ],
-    dependencies: [],
+    dependencies: [
+        .package(name: "FlutterFramework", path: "../FlutterFramework")
+    ],
     targets: [
         .target(
             name: "sign_in_with_apple",
-            dependencies: [],
+            dependencies: [
+                .product(name: "FlutterFramework", package: "FlutterFramework")
+            ],
             resources: []
         )
     ]

--- a/packages/sign_in_with_apple/sign_in_with_apple/example/lib/main.dart
+++ b/packages/sign_in_with_apple/sign_in_with_apple/example/lib/main.dart
@@ -7,7 +7,8 @@ import 'package:sign_in_with_apple/sign_in_with_apple.dart';
 
 // Needed because we can't import `web` into a mobile app,
 // while on the flip-side access to `dart:io` throws at runtime (hence the `kIsWeb` check below)
-import 'html_shim.dart' if (dart.library.js_interop) 'package:web/web.dart'
+import 'html_shim.dart'
+    if (dart.library.js_interop) 'package:web/web.dart'
     show window;
 
 void main() {
@@ -34,9 +35,7 @@ class _MyAppState extends State<MyApp> {
         return null;
       }),
       home: Scaffold(
-        appBar: AppBar(
-          title: const Text('Example app: Sign in with Apple'),
-        ),
+        appBar: AppBar(title: const Text('Example app: Sign in with Apple')),
         body: Container(
           padding: const EdgeInsets.all(10),
           child: Center(
@@ -57,10 +56,10 @@ class _MyAppState extends State<MyApp> {
                         // NOTE(tp): For package local development use (as described in `Development.md`)
                         // Uri.parse('https://siwa-flutter-plugin.dev/')
                         kIsWeb
-                            ? Uri.parse('https://${window.location.host}/')
-                            : Uri.parse(
-                                'https://flutter-sign-in-with-apple-example.glitch.me/callbacks/sign_in_with_apple',
-                              ),
+                        ? Uri.parse('https://${window.location.host}/')
+                        : Uri.parse(
+                            'https://flutter-sign-in-with-apple-example.glitch.me/callbacks/sign_in_with_apple',
+                          ),
                   ),
                   // TODO: Remove these if you have no need for them
                   nonce: 'example-nonce',
@@ -84,8 +83,8 @@ class _MyAppState extends State<MyApp> {
                       'lastName': credential.familyName!,
                     'useBundleId':
                         !kIsWeb && (Platform.isIOS || Platform.isMacOS)
-                            ? 'true'
-                            : 'false',
+                        ? 'true'
+                        : 'false',
                     if (credential.state != null) 'state': credential.state!,
                   },
                 );

--- a/packages/sign_in_with_apple/sign_in_with_apple/example/pubspec.lock
+++ b/packages/sign_in_with_apple/sign_in_with_apple/example/pubspec.lock
@@ -5,26 +5,26 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.0"
+    version: "2.13.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   characters:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
@@ -58,10 +58,10 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: e2a421b7e59244faef694ba7b30562e489c2b489866e505074eb005cd7060db7
+      sha256: "9e8c3858111da373efc5aa341de011d9bd23e2c5c5e0c62bccf32438e192d7b1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -76,18 +76,18 @@ packages:
     dependency: "direct main"
     description:
       name: http
-      sha256: bb2ce4590bc2667c96f318d68cac1b5a7987ec819351d32b1c987239a815e007
+      sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.0"
+    version: "1.6.0"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
-      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
+      sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.2"
+    version: "4.1.2"
   leak_tracker:
     dependency: transitive
     description:
@@ -124,26 +124,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   path:
     dependency: transitive
     description:
@@ -166,7 +166,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "7.0.1"
+    version: "8.0.0"
   sign_in_with_apple_platform_interface:
     dependency: "direct overridden"
     description:
@@ -190,10 +190,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.10.1"
   stack_trace:
     dependency: transitive
     description:
@@ -214,34 +214,34 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.4.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: "19a78f63e83d3a61f00826d09bc2f60e191bf3504183c001262be6ac75589fb8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.8"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      sha256: facc8d6582f16042dd49f2463ff1bd6e2c9ef9f3d5da3d9b087e244a7b564b3c
+      sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.4.0"
   vector_math:
     dependency: transitive
     description:
@@ -254,10 +254,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: "45caa6c5917fa127b5dbcfbd1fa60b14e583afdc08bfc96dda38886ca252eb60"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "15.0.2"
   web:
     dependency: transitive
     description:
@@ -267,5 +267,5 @@ packages:
     source: hosted
     version: "1.1.1"
 sdks:
-  dart: ">=3.8.0-0 <4.0.0"
-  flutter: ">=3.35.0"
+  dart: ">=3.11.0 <4.0.0"
+  flutter: ">=3.41.0 <4.0.0"

--- a/packages/sign_in_with_apple/sign_in_with_apple/example/pubspec.yaml
+++ b/packages/sign_in_with_apple/sign_in_with_apple/example/pubspec.yaml
@@ -4,8 +4,8 @@ publish_to: "none"
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.3.0
-  flutter: ">=3.35.0 <4.0.0"
+  sdk: ^3.11.0
+  flutter: ">=3.41.0 <4.0.0"
 
 dependencies:
   flutter:

--- a/packages/sign_in_with_apple/sign_in_with_apple/pubspec.lock
+++ b/packages/sign_in_with_apple/sign_in_with_apple/pubspec.lock
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
@@ -108,26 +108,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: "direct main"
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   path:
     dependency: transitive
     description:
@@ -209,10 +209,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: "19a78f63e83d3a61f00826d09bc2f60e191bf3504183c001262be6ac75589fb8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.8"
   vector_math:
     dependency: transitive
     description:
@@ -230,5 +230,5 @@ packages:
     source: hosted
     version: "13.0.0"
 sdks:
-  dart: ">=3.9.0 <4.0.0"
-  flutter: ">=3.35.0"
+  dart: ">=3.11.0 <4.0.0"
+  flutter: ">=3.41.0 <4.0.0"

--- a/packages/sign_in_with_apple/sign_in_with_apple/pubspec.yaml
+++ b/packages/sign_in_with_apple/sign_in_with_apple/pubspec.yaml
@@ -1,12 +1,12 @@
 name: sign_in_with_apple
 description: Flutter bridge to initiate Sign in with Apple (on iOS, macOS, and Android). Includes support for keychain entries as well as signing in with an Apple ID.
-version: 7.0.1
+version: 8.0.0
 homepage: https://github.com/aboutyou/dart_packages/tree/master/packages/sign_in_with_apple
 repository: https://github.com/aboutyou/dart_packages
 
 environment:
-  sdk: ^3.9.0
-  flutter: ">=3.35.0"
+  sdk: ^3.11.0
+  flutter: ">=3.41.0 <4.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
Prepare the 8.0.0 release with Swift Package Manager (SPM) support.

This bumps the minimum Flutter version to 3.41 as the SPM integration changed a bit.
With the upcoming 3.44 release, SPM will be the default, so we need to get ready to support this for new projects.

https://blog.flutter.dev/saying-goodbye-to-cocoapods-swift-package-manager-is-soon-the-default-in-flutter-645a92714a57
https://docs.flutter.dev/packages-and-plugins/swift-package-manager/for-plugin-authors